### PR TITLE
Added more source files to exclude list in _config.yml.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -75,13 +75,19 @@ production_url:  https://jekyller.github.io/jasper2/
 source_url:  https://github.com/jekyller/jasper2/
 
 exclude:
-  - README.md
-  - Rakefile
-  - Gemfile
-  - Gemfile.lock
-  - changelog.md
-  - "*.Rmd"
+  - assets/css
+  - node_modules
   - vendor
   - .travis.yml
-  - node_modules
-  - .git
+  - Gemfile
+  - Gemfile.lock
+  - GHOST.txt
+  - gulpfile.js
+  - LICENSE
+  - package.json
+  - Rakefile
+  - README.md
+  - script.py
+  - changelog.md
+  - "*.Rmd"
+  - .git*


### PR DESCRIPTION
With this update, several more files are added to the exclude list in _config.yml that aren't necessary in the target directory. The exclude list has also been sorted to match the directory sort order, which makes it a little easier to cross check. Notably, this update adds _assets/css_ to the excluded list as the files in use within the template pages are pulled from the _assets/built_ directory leaving the _assets/css_ directory unused. Overall the intent of this update is to reduce duplicated code and compress the size of repository.

Signed-off-by: Kane McConnell <kane@makanal.eu>